### PR TITLE
Use Int Precision w/Vips During Sharpen

### DIFF
--- a/lib/image_processing/vips.rb
+++ b/lib/image_processing/vips.rb
@@ -140,7 +140,7 @@ module ImageProcessing
         else
           image = self.image.thumbnail_image(width, height: height, **options)
         end
-        image = image.conv(sharpen) if sharpen
+        image = image.conv(sharpen, precision: :int) if sharpen
         image
       end
 

--- a/lib/image_processing/vips.rb
+++ b/lib/image_processing/vips.rb
@@ -140,7 +140,7 @@ module ImageProcessing
         else
           image = self.image.thumbnail_image(width, height: height, **options)
         end
-        image = image.conv(sharpen, precision: :int) if sharpen
+        image = image.conv(sharpen, precision: :integer) if sharpen
         image
       end
 

--- a/test/vips_test.rb
+++ b/test/vips_test.rb
@@ -174,6 +174,11 @@ describe "ImageProcessing::Vips" do
       normal    = @pipeline.resize_to_limit!(400, 400, sharpen: false)
       assert sharpened.size > normal.size, "Expected sharpened thumbnail to have bigger filesize than not sharpened thumbnail"
     end
+
+    it "sharpening uses integer precision" do
+      sharpened = @pipeline.resize_to_limit(400, 400).call(save: false)
+      assert_equal :uchar, sharpened.format
+    end
   end
 
   describe "#resize_to_fit" do
@@ -217,6 +222,11 @@ describe "ImageProcessing::Vips" do
       normal    = @pipeline.resize_to_fit!(400, 400, sharpen: false)
       assert sharpened.size > normal.size, "Expected sharpened thumbnail to have bigger filesize than not sharpened thumbnail"
     end
+
+    it "sharpening uses integer precision" do
+      sharpened = @pipeline.resize_to_limit(400, 400).call(save: false)
+      assert_equal :uchar, sharpened.format
+    end
   end
 
   describe "#resize_to_fill" do
@@ -247,6 +257,11 @@ describe "ImageProcessing::Vips" do
       sharpened = @pipeline.resize_to_fill!(400, 400, sharpen: ImageProcessing::Vips::Processor::SHARPEN_MASK)
       normal   = @pipeline.resize_to_fill!(400, 400, sharpen: false)
       assert sharpened.size > normal.size, "Expected sharpened thumbnail to have bigger filesize than not sharpened thumbnail"
+    end
+
+    it "sharpening uses integer precision" do
+      sharpened = @pipeline.resize_to_limit(400, 400).call(save: false)
+      assert_equal :uchar, sharpened.format
     end
   end
 
@@ -296,6 +311,11 @@ describe "ImageProcessing::Vips" do
       sharpened = @pipeline.resize_and_pad!(400, 400, sharpen: ImageProcessing::Vips::Processor::SHARPEN_MASK)
       normal    = @pipeline.resize_and_pad!(400, 400, sharpen: false)
       assert sharpened.size > normal.size, "Expected sharpened thumbnail to have bigger filesize than not sharpened thumbnail"
+    end
+
+    it "sharpening uses integer precision" do
+      sharpened = @pipeline.resize_to_limit(400, 400).call(save: false)
+      assert_equal :uchar, sharpened.format
     end
   end
 


### PR DESCRIPTION
Work in #22 added automatic image sharpening for Vips. However, discovered in #55 `conv()` defaults to float precision and can leave to visual artifacts in some scenarios. Per @jcupitt recommendation, we can add `precision: :int` to conv and this should also give us a speed-up, since int convolutions will use SIMD.

Fixes #55