### PR TITLE
Fix Ruby 2.7 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - jruby-9.2.6.0
 
 # Doesn't currently work with MRI 2.5.1: https://github.com/travis-ci/travis-ci/issues/8978

--- a/lib/image_processing/chainable.rb
+++ b/lib/image_processing/chainable.rb
@@ -32,6 +32,8 @@ module ImageProcessing
           builder.send(name)
         elsif argument.is_a?(Array)
           builder.send(name, *argument)
+        elsif argument.is_a?(Hash)
+          builder.send(name, **argument)
         else
           builder.send(name, argument)
         end
@@ -46,6 +48,7 @@ module ImageProcessing
 
       operation(name, *args, &block)
     end
+    ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
     # Add an operation defined by the processor.
     def operation(name, *args, &block)
@@ -59,7 +62,7 @@ module ImageProcessing
       options = options.merge(source: file) if file
       options = options.merge(destination: destination) if destination
 
-      branch(options).call!(**call_options)
+      branch(**options).call!(**call_options)
     end
 
     # Creates a new builder object, merging current options with new options.

--- a/lib/image_processing/mini_magick.rb
+++ b/lib/image_processing/mini_magick.rb
@@ -32,7 +32,7 @@ module ImageProcessing
           source_path = path_or_magick
           magick = ::MiniMagick::Tool::Convert.new
 
-          Utils.apply_options(magick, options)
+          Utils.apply_options(magick, **options)
 
           input  = source_path
           input  = "#{loader}:#{input}" if loader
@@ -50,7 +50,7 @@ module ImageProcessing
       # the result to disk. Accepts additional options related to saving the
       # image (e.g. quality).
       def self.save_image(magick, destination_path, allow_splitting: false, **options)
-        Utils.apply_options(magick, options)
+        Utils.apply_options(magick, **options)
 
         magick << destination_path
         magick.call

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -110,7 +110,7 @@ describe "ImageProcessing::Pipeline" do
     actual1 = pipeline
       .apply(
         loader:        { autorotate: true },
-        resize_to_fit: [400, 400],
+        resize_to_fit: [400, 400, sharpen: false],
         invert:        true,
         rot90:         nil,
         rot:           :d90,
@@ -122,7 +122,7 @@ describe "ImageProcessing::Pipeline" do
     actual2 = pipeline
       .apply([
         [:loader,        { autorotate: true }],
-        [:resize_to_fit, [400, 400]],
+        [:resize_to_fit, [400, 400, sharpen: false]],
         [:invert,        true],
         [:rot90,         nil],
         [:rot,           :d90],
@@ -132,7 +132,7 @@ describe "ImageProcessing::Pipeline" do
 
     expected = pipeline
       .loader(autorotate: true)
-      .resize_to_fit(400, 400)
+      .resize_to_fit(400, 400, sharpen: false)
       .invert
       .rot90
       .rot(:d90)


### PR DESCRIPTION
Rails CI with Ruby master has broken by https://github.com/ruby/ruby/pull/2794.

https://buildkite.com/rails/rails/builds/66163#c6c0c423-bb9b-4c20-bab4-8a6aa56c726d/936-1205

To fix the CI failure, fixing kwargs deprecation warnings is required.