### PR TITLE
Disable sharpening with mini magick by default

### DIFF
--- a/lib/image_processing/mini_magick.rb
+++ b/lib/image_processing/mini_magick.rb
@@ -161,7 +161,7 @@ module ImageProcessing
 
       # Resizes the image using the specified geometry, and sharpens the
       # resulting thumbnail.
-      def thumbnail(geometry, sharpen: {})
+      def thumbnail(geometry, sharpen: nil)
         magick.resize(geometry)
 
         if sharpen


### PR DESCRIPTION
The sharpening causes visible rough edges to appear in resized jpeg
images.