### PR TITLE
Fix format fallback for files ending in with a dot

### DIFF
--- a/lib/image_processing/pipeline.rb
+++ b/lib/image_processing/pipeline.rb
@@ -37,9 +37,9 @@ module ImageProcessing
 
     # Determines the appropriate destination image format.
     def destination_format
-      format   = File.extname(destination)[1..-1] if destination
+      format   = determine_format(destination) if destination
       format ||= self.format
-      format ||= File.extname(source_path)[1..-1] if source_path
+      format ||= determine_format(source_path) if source_path
 
       format || DEFAULT_FORMAT
     end
@@ -92,6 +92,12 @@ module ImageProcessing
       else
         @source
       end
+    end
+
+    def determine_format(file_path)
+      extension = File.extname(file_path)
+
+      extension[1..-1] if extension.size > 1
     end
   end
 end

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -46,6 +46,13 @@ describe "ImageProcessing::Pipeline" do
     assert_type "JPEG", result
   end
 
+  it "saves as JPEG when format is unknown and the path ends with a '.'" do
+    png = ImageProcessing::Vips.convert("png").call(@portrait)
+    result = ImageProcessing::Vips.invert.call(copy_to_tempfile(png, "."))
+    assert_equal ".jpg", File.extname(result.path)
+    assert_type "JPEG", result
+  end
+
   it "accepts destination path" do
     destination = Tempfile.new(["destination", ".jpg"])
     ImageProcessing::Vips.source(@portrait).call(destination: destination.path)


### PR DESCRIPTION
`File.extname` was [updated in ruby 2.7](https://bugs.ruby-lang.org/issues/15244) to return `"."` when the file ends in a dot. Previously it was returning an empty string.

This can break determining the destination format. Specifically this crashed for us in Shrine's derivation endpoint because the `source_path` there looks something like `/var/folders/w5/rdvk3_yx50n3slrls87vcz6w0000gn/T/shrine20201006-36115-1p007ne.`.