### PR TITLE
allow resize_to_fill to skip cropping #74

### DIFF
--- a/lib/image_processing/mini_magick.rb
+++ b/lib/image_processing/mini_magick.rb
@@ -69,9 +69,11 @@ module ImageProcessing
       end
 
       # Resizes the image to fill the specified dimensions, applying any
-      # necessary cropping.
-      def resize_to_fill(width, height, gravity: "Center", **options)
+      # necessary cropping. Passing crop: false will treat each
+      # dimmension as a minimum and overflow as needed.
+      def resize_to_fill(width, height, gravity: "Center", crop: true, **options)
         thumbnail("#{width}x#{height}^", **options)
+        return magick unless crop
         magick.gravity gravity
         magick.background color(:transparent)
         magick.extent "#{width}x#{height}"

--- a/test/mini_magick_test.rb
+++ b/test/mini_magick_test.rb
@@ -264,6 +264,10 @@ describe "ImageProcessing::MiniMagick" do
       assert_dimensions [1000, 1000], @pipeline.resize_to_fill!(1000, 1000)
     end
 
+    it "will skip cropping if asked" do
+      assert_dimensions [400, 533], @pipeline.resize_to_fill!(400, 400, crop: false)
+    end
+
     it "produces correct image" do
       expected = fixture_image("fill.jpg")
       assert_similar expected, @pipeline.resize_to_fill!(400, 400)


### PR DESCRIPTION
Adds the ability to pass `crop: false` to `MiniMagick#resize_to_fill` per #74 

Unfortunately, I could not figure out a way to make this to work the same on the vips side.