### PR TITLE
fix typo in documentation

### DIFF
--- a/doc/minimagick.md
+++ b/doc/minimagick.md
@@ -321,7 +321,7 @@ processing, otherwise if `nil` is returned the original
 `MiniMagick::Tool::Convert` object will be used.
 
 ```rb
-ImagePocessing::MiniMagick
+ImageProcessing::MiniMagick
   .custom { |magick| magick.colorspace("grayscale") if gray? }
   # ...
 ```


### PR DESCRIPTION
Correct spelling of `ImageProcessing` in ImageProcessing::MiniMagick documentation