### PR TITLE
Add `analyze` methods for getting metadata

### DIFF
--- a/lib/image_processing.rb
+++ b/lib/image_processing.rb
@@ -1,6 +1,7 @@
 require "image_processing/chainable"
 require "image_processing/builder"
 require "image_processing/pipeline"
+require "image_processing/analyzer"
 require "image_processing/processor"
 require "image_processing/version"
 

--- a/lib/image_processing/analyzer.rb
+++ b/lib/image_processing/analyzer.rb
@@ -1,0 +1,12 @@
+module ImageProcessing
+  # Abstract class inherited by individual analyzers.
+  class Analyzer
+    def initialize(image)
+      @image = image
+    end
+
+    def analyze
+      { width: @image.width, height: @image.height, rotated: rotated? }
+    end
+  end
+end

--- a/lib/image_processing/mini_magick.rb
+++ b/lib/image_processing/mini_magick.rb
@@ -16,6 +16,27 @@ module ImageProcessing
       false
     end
 
+    def self.analyze(file)
+      if valid_image?(file)
+        image = ::MiniMagick::Image.new(file.path)
+        Analyzer.new(image).analyze
+      else
+        {}
+      end
+    end
+
+    class Analyzer < ImageProcessing::Analyzer
+      ROTATIONS = %w[ RightTop LeftBottom TopRight BottomLeft ]
+
+      private
+
+      def rotated?
+        ROTATIONS.include?(@image["%[orientation]"])
+      rescue ::MiniMagick::Error
+        false
+      end
+    end
+
     class Processor < ImageProcessing::Processor
       accumulator :magick, ::MiniMagick::Tool
 

--- a/test/mini_magick_test.rb
+++ b/test/mini_magick_test.rb
@@ -106,6 +106,24 @@ describe "ImageProcessing::MiniMagick" do
     assert_dimensions [300, 400], pipeline.loader(geometry: "400x400").call
   end unless ENV["GM"]
 
+  it "analyzes the image" do
+    result = ImageProcessing::MiniMagick.analyze(@portrait)
+    expected = { width: 600, height: 800, rotated: false }
+    assert_equal expected, result
+  end
+
+  it "analyzes the rotated image" do
+    result = ImageProcessing::MiniMagick.analyze(fixture_image("rotated.jpg"))
+    expected = { width: 800, height: 600, rotated: true }
+    assert_equal expected, result
+  end
+
+  it "does not analyze an invalid image" do
+    result = ImageProcessing::MiniMagick.analyze(fixture_image("invalid.jpg"))
+    expected = {}
+    assert_equal expected, result
+  end
+
   it "auto orients by default" do
     result = ImageProcessing::MiniMagick.call(fixture_image("rotated.jpg"))
     assert_dimensions [600, 800], result

--- a/test/vips_test.rb
+++ b/test/vips_test.rb
@@ -76,6 +76,24 @@ describe "ImageProcessing::Vips" do
     assert_dimensions [600, 800], result
   end
 
+  it "analyzes a image" do
+    result = ImageProcessing::Vips.analyze(@portrait)
+    expected = { width: 600, height: 800, rotated: false }
+    assert_equal expected, result
+  end
+
+  it "analyzes a rotated image" do
+    result = ImageProcessing::Vips.analyze(fixture_image("rotated.jpg"))
+    expected = { width: 800, height: 600, rotated: true }
+    assert_equal expected, result
+  end
+
+  it "does not analyze an invalid image" do
+    result = ImageProcessing::Vips.analyze(fixture_image("invalid.jpg"))
+    expected = {}
+    assert_equal expected, result
+  end
+
   it "applies loader options" do
     result = ImageProcessing::Vips.loader(shrink: 2).call(@portrait)
     assert_dimensions [300, 400], result


### PR DESCRIPTION
Besides processing images it would be nice to analyze images as well to get metadata like: width, height and rotation.
This is currently based on the ActiveStorage::Analyzer::ImageAnalyzer. I'd like to move that logic to ImageProcessing instead.

ActiveStorage currently logs if analyzing doesn't work, or if the image is invalid. Not sure if we should raise an error in `analyze` instead, or maybe keep the image validation out of analyze.