### PR TITLE
Fix failing test

### DIFF
--- a/test/vips_test.rb
+++ b/test/vips_test.rb
@@ -306,7 +306,7 @@ describe "ImageProcessing::Vips" do
 
     it "accepts thumbnail options" do
       pad  = @pipeline.resize_and_pad!(400, 400)
-      crop = @pipeline.resize_and_pad!(400, 400, crop: :centre)
+      crop = @pipeline.resize_and_pad!(400, 400, crop: :entropy)
       refute_similar pad, crop
     end
 


### PR DESCRIPTION
The following test currently fails on CI:

   1) Failure:
      ImageProcessing::Vips::#resize_and_pad#test_0006_accepts thumbnail
      options [/home/runner/work/image_processing/image_processing/test/vips_test.rb:310]:
      Expected 1 to be > 3.

By using `:entropy` instead of `:centre` the images differ more according to DHash.

As this test seems to test that the options passed to `resize_and_pad!`
are applied, the actual `:crop` option shouldn't matter.
