### PR TITLE
use rot command where possible

### DIFF
--- a/lib/image_processing/vips.rb
+++ b/lib/image_processing/vips.rb
@@ -92,7 +92,12 @@ module ImageProcessing
 
       # Rotates the image by an arbitrary angle.
       def rotate(degrees, **options)
-        image.similarity(angle: degrees, **options)
+        if ([0, 90, 180, 270].include?(degrees) && options.empty?)
+          rot_command = "rot#{degrees}".to_sym
+          image.public_send rot_command
+        else
+          image.similarity(angle: degrees, **options)
+        end
       end
 
       # Overlays the specified image over the current one. Supports specifying


### PR DESCRIPTION
The similarity command leaves a line on the side of 90/180/270 rotations. This PR uses the rot command where possible.

resolves #104 