### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/image_processing.gemspec
+++ b/image_processing.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["README.md", "LICENSE.txt", "CHANGELOG.md", "lib/**/*.rb", "*.gemspec"]
   spec.require_paths = ["lib"]
 
+  spec.metadata = { "rubygems_mfa_required" => "true" }
+
   spec.add_dependency "mini_magick", ">= 4.9.5", "< 5"
   spec.add_dependency "ruby-vips", ">= 2.0.17", "< 3"
 


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/