### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/image_processing

### DIFF
--- a/image_processing.gemspec
+++ b/image_processing.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["README.md", "LICENSE.txt", "CHANGELOG.md", "lib/**/*.rb", "*.gemspec"]
   spec.require_paths = ["lib"]
 
-  spec.metadata = { "rubygems_mfa_required" => "true" }
+  spec.metadata = { "changelog_uri" => spec.homepage + "/blob/master/CHANGELOG.md",
+                    "rubygems_mfa_required" => "true" }
 
   spec.add_dependency "mini_magick", ">= 4.9.5", "< 5"
   spec.add_dependency "ruby-vips", ">= 2.0.17", "< 3"


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/image_processing which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/