### PR TITLE
Upgrade minimagick 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
+gemfiles/*.lock
 pkg/

--- a/gemfiles/mini_magick4.gemfile
+++ b/gemfiles/mini_magick4.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec :path => '../'
+
+gem 'pry'
+
+gem 'mini_magick', '~> 4.9'

--- a/gemfiles/mini_magick5.gemfile
+++ b/gemfiles/mini_magick5.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec :path => '../'
+
+gem 'pry'
+
+gem 'mini_magick', '~> 5.0'

--- a/image_processing.gemspec
+++ b/image_processing.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata = { "changelog_uri" => spec.homepage + "/blob/master/CHANGELOG.md",
                     "rubygems_mfa_required" => "true" }
 
-  spec.add_dependency "mini_magick", ">= 4.9.5", "< 5"
+  spec.add_dependency "mini_magick", ">= 4.9.5", "< 6"
   spec.add_dependency "ruby-vips", ">= 2.0.17", "< 3"
 
   spec.add_development_dependency "rake"

--- a/lib/image_processing/mini_magick.rb
+++ b/lib/image_processing/mini_magick.rb
@@ -5,18 +5,19 @@ module ImageProcessing
   module MiniMagick
     extend Chainable
 
+    def self.convert_shim(&block)
+      if ::MiniMagick.respond_to?(:convert)
+        ::MiniMagick.convert(&block)
+      else
+        ::MiniMagick::Tool::Convert.new(&block)
+      end
+    end
+
     # Returns whether the given image file is processable.
     def self.valid_image?(file)
-      if ::MiniMagick.respond_to?(:convert)
-        ::MiniMagick.convert do |convert|
-          convert << file.path
-          convert << "null:"
-        end
-      else
-        ::MiniMagick::Tool::Convert.new do |convert|
-          convert << file.path
-          convert << "null:"
-        end
+      convert_shim do |convert|
+        convert << file.path
+        convert << "null:"
       end
       true
     rescue ::MiniMagick::Error
@@ -37,7 +38,7 @@ module ImageProcessing
           magick = path_or_magick
         else
           source_path = path_or_magick
-          magick = ::MiniMagick::Tool::Convert.new
+          magick = ::ImageProcessing::MiniMagick.convert_shim
 
           Utils.apply_options(magick, **options)
 

--- a/lib/image_processing/mini_magick.rb
+++ b/lib/image_processing/mini_magick.rb
@@ -7,9 +7,16 @@ module ImageProcessing
 
     # Returns whether the given image file is processable.
     def self.valid_image?(file)
-      ::MiniMagick::Tool::Convert.new do |convert|
-        convert << file.path
-        convert << "null:"
+      if ::MiniMagick.respond_to?(:convert)
+        ::MiniMagick.convert do |convert|
+          convert << file.path
+          convert << "null:"
+        end
+      else
+        ::MiniMagick::Tool::Convert.new do |convert|
+          convert << file.path
+          convert << "null:"
+        end
       end
       true
     rescue ::MiniMagick::Error

--- a/test/mini_magick_test.rb
+++ b/test/mini_magick_test.rb
@@ -14,7 +14,7 @@ describe "ImageProcessing::MiniMagick" do
   it "applies imagemagick operations" do
     actual = ImageProcessing::MiniMagick.flip.call(@portrait)
     expected = Tempfile.new(["result", ".jpg"], binmode: true).tap do |tempfile|
-      MiniMagick::Tool::Convert.new do |cmd|
+      ImageProcessing::MiniMagick.convert_shim do |cmd|
         cmd << @portrait.path
         cmd.flip
         cmd << tempfile.path
@@ -37,7 +37,7 @@ describe "ImageProcessing::MiniMagick" do
   it "applies macro operations" do
     actual = ImageProcessing::MiniMagick.resize_to_limit(400, 400).call(@portrait)
     expected = Tempfile.new(["result", ".jpg"], binmode: true).tap do |tempfile|
-      MiniMagick::Tool::Convert.new do |cmd|
+      ImageProcessing::MiniMagick.convert_shim do |cmd|
         cmd << @portrait.path
         cmd.resize("400x400")
         cmd << tempfile.path
@@ -55,7 +55,7 @@ describe "ImageProcessing::MiniMagick" do
 
   it "accepts page" do
     tiff = Tempfile.new(["file", ".tiff"])
-    MiniMagick::Tool::Convert.new do |convert|
+    ImageProcessing::MiniMagick.convert_shim do |convert|
       convert.merge! [@portrait.path, @portrait.path, @portrait.path]
       convert << tiff.path
     end
@@ -70,7 +70,7 @@ describe "ImageProcessing::MiniMagick" do
 
   it "disallows split layers by default" do
     tiff = Tempfile.new(["file", ".tiff"])
-    MiniMagick::Tool::Convert.new do |convert|
+    ImageProcessing::MiniMagick.convert_shim do |convert|
       convert.merge! [@portrait.path, @portrait.path, @portrait.path]
       convert << tiff.path
     end
@@ -168,7 +168,7 @@ describe "ImageProcessing::MiniMagick" do
   end
 
   it "accepts magick object as source" do
-    magick = MiniMagick::Tool::Convert.new
+    magick = ImageProcessing::MiniMagick.convert_shim
     magick << fixture_image("rotated.jpg").path
     result = ImageProcessing::MiniMagick.source(magick).call
     assert_dimensions [600, 800], result
@@ -568,7 +568,7 @@ describe "ImageProcessing::MiniMagick" do
     it "appends CLI arguments" do
       actual = ImageProcessing::MiniMagick.append("-resize", "400x400").call(@portrait)
       expected = Tempfile.new(["result", ".jpg"], binmode: true).tap do |tempfile|
-        MiniMagick::Tool::Convert.new do |cmd|
+        ImageProcessing::MiniMagick.convert_shim do |cmd|
           cmd << @portrait.path
           cmd.resize("400x400")
           cmd << tempfile.path


### PR DESCRIPTION
Using just the specs as a guide, this seems like a fairly minimal set of changes that would permit support for minimagick 5, addressing all deprecation warnings. 

It also introduces distinct gemfiles for minimagick v4 and v5 which could both be run in CI. I have not yet modified the Github actions yaml to do that, but should be pretty easy to do. 

A couple specs are still failing, related to the `strip` command, but I figured it would be worth posting this to see if it seems like the right direction before spending more time on it. 