### PR TITLE
Fix bug in resize_to_cover where the image is provided as a string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 pkg/
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Fix `#resize_to_cover` when dealing with EXIF orientated images (@brendon)
+
 ## 1.13.0 (2024-07-24)
 
 * [minimagick] Use `-append` when calling `#append` with no arguments (@janko)

--- a/lib/image_processing/vips.rb
+++ b/lib/image_processing/vips.rb
@@ -93,7 +93,7 @@ module ImageProcessing
       # Resizes the image to cover the specified dimensions, without
       # cropping the excess.
       def resize_to_cover(width, height, **options)
-        image = self.image.is_a?(String) ? ::Vips::Image.new_from_file(self.image) : self.image
+        image = self.image.is_a?(String) ? self.class.load_image(self.image) : self.image
 
         image_ratio = Rational(image.width, image.height)
         thumbnail_ratio = Rational(width, height)

--- a/test/vips_test.rb
+++ b/test/vips_test.rb
@@ -7,6 +7,7 @@ describe "ImageProcessing::Vips" do
     @portrait  = fixture_image("portrait.jpg")
     @landscape = fixture_image("landscape.jpg")
     @square = fixture_image("square.jpg")
+    @exif_portrait = fixture_image("exif_portrait.jpg")
   end
 
   it "applies vips operations" do
@@ -328,6 +329,7 @@ describe "ImageProcessing::Vips" do
       @portrait_pipeline = ImageProcessing::Vips.source(@portrait)
       @landscape_pipeline = ImageProcessing::Vips.source(@landscape)
       @square_pipeline = ImageProcessing::Vips.source(@square)
+      @exif_portrait_pipeline = ImageProcessing::Vips.source(@exif_portrait)
     end
 
     it "resizes the portrait image to fill out the given landscape dimensions" do
@@ -386,6 +388,10 @@ describe "ImageProcessing::Vips" do
     it "sharpening uses integer precision" do
       sharpened = @portrait_pipeline.resize_to_cover(400, 400).call(save: false)
       assert_equal :uchar, sharpened.format
+    end
+
+    it "works correctly with EXIF orientation" do
+      assert_dimensions [300, 617], @exif_portrait_pipeline.resize_to_cover!(300, 200)
     end
   end
 


### PR DESCRIPTION
This appears to be a good fix. My original implementation always assumed `image` existed because we didn't use `resize_to` in the method name:

https://github.com/janko/image_processing/blob/56a839ed53dea7f48dc1202cde86989ec1fc01fe/lib/image_processing/processor.rb#L9-L16

Not sure if there are any functional differences in how we load the image here and how it's loaded in `processor.rb`.

Probably the better fix would be to use another system for determining which methods need the image to be loaded first rather than relying on the method name.

Closes #134