### PR TITLE
Warn and reraise LoadError instead of raising custom error

### DIFF
--- a/lib/image_processing/mini_magick.rb
+++ b/lib/image_processing/mini_magick.rb
@@ -1,8 +1,8 @@
 require "image_processing"
 begin
   require "mini_magick"
-rescue LoadError
-  fail ImageProcessing::Error, "ImageProcessing::MiniMagick requires the mini_magick gem. Please add `gem \"mini_magick\", \"~> 5.0\"` to your Gemfile."
+rescue LoadError => e
+  raise e, "ImageProcessing::MiniMagick requires the mini_magick gem. Please add `gem \"mini_magick\", \"~> 5.0\"` to your Gemfile."
 end
 
 module ImageProcessing

--- a/lib/image_processing/vips.rb
+++ b/lib/image_processing/vips.rb
@@ -1,8 +1,8 @@
 require "image_processing"
 begin
   require "vips"
-rescue LoadError
-  fail ImageProcessing::Error, "ImageProcessing::Vips requires the ruby-vips gem. Please add `gem \"ruby-vips\", \"~> 2.0\"` to your Gemfile."
+rescue LoadError => e
+  raise e, "ImageProcessing::Vips requires the ruby-vips gem. Please add `gem \"ruby-vips\", \"~> 2.0\"` to your Gemfile."
 end
 
 Vips.block_untrusted(true) if Vips.respond_to?(:block_untrusted) && !ENV["VIPS_BLOCK_UNTRUSTED"]


### PR DESCRIPTION
When upgrading to image_processing 2.0 and removing the image_magick gem (which we don't use) we ran into errors with Tapioca requiring all gems to compile RBI files. The quick fix was to add back image_magick, but the IMO proper fix is re-raising the original LoadError from Bundler which is [handled by Tapioca](https://github.com/Shopify/tapioca/blob/0d4664bab37ca180dca3dad59a61ae282b1075fe/lib/tapioca/loaders/gem.rb#L60). With these changes Tapioca can compile RBI for image_processing, just without the `ImageProcessing::MiniMagick` module being present.

The warn + reraise pattern is for example how Rails handles bcrypt: https://github.com/rails/rails/blob/fa8f0812160665bff083a089d2bb2fc1817ea03e/activemodel/lib/active_model/secure_password.rb#L129-L134